### PR TITLE
Support router mode and simplify address config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@ An ansible role that installs tinc on Ubuntu.
 
 Tested on ubuntu 14.04 (Trusty), Fedora 24, CentOS7 and RHEL7.
 
-Only tested for L2 mesh setup.
+Tested for L2 mesh ('switch' mode, the default for this role) and routed setup
+('router' mode).
 
 Role Variables
 --------------
 
 Each tinc configuration is mapped to a variable (see `defaults/main.yml`)
 
-Generate an tincd key:
+Generate an tincd key on each host participating in the VPN:
 
     tincd -n test -K4096
 
-With this information set ```tinc_rsa_key```
+With this information set ```tinc_rsa_key``` in host-specific configuration.
 
 In order to setup a simple point to point vpn, common variables:
 
@@ -24,17 +25,21 @@ In order to setup a simple point to point vpn, common variables:
       - vpn: test #vpn name
         name: host1
         address: 192.168.205.10 #local adddress
-        subnet: 172.10.10.10/24 # ip address to use in the vpn interface
+        vpn_address: 172.10.10.10 # ip address to use in the vpn interface
+        vpn_prefixlength: 24 # tells which hosts in VPN are directly reachable
         public_key: |
           -----BEGIN RSA PUBLIC KEY-----
           -----END RSA PUBLIC KEY-----
       - vpn: test
         name: host2
         address: 192.168.205.11
-        subnet: 172.10.10.11/24
+        vpn_address: 172.10.10.11
+        vpn_prefixlength: 24
         public_key: |
           -----BEGIN RSA PUBLIC KEY-----
           -----END RSA PUBLIC KEY-----
+
+Host-specific configuration:
 
 host1:
 
@@ -45,10 +50,34 @@ host1:
 
 host2:
 
-    tinc_hostname: host1
+    tinc_hostname: host2
     tinc_rsa_key: |
       -----BEGIN RSA PRIVATE KEY-----
       -----END RSA PRIVATE KEY-----
+
+More Complicated Networks
+-------------------------
+If you have a more complicated network, such as where each node in the
+mesh is not fully connected, or where a node has additional hosts behind it,
+you can set the 'subnet' value for each element in tinc_vpn. This will be
+passed directly to the Subnet field in that host's configuration file. If
+subnet is not specified, it will be set to:
+
+{{vpn_address}}/32
+
+which tells tinc that each host on the VPN can be contacted directly, which is the
+simplest configuration.
+
+Switch vs Router Mode
+---------------------
+
+To use a routed configuration rather than an L2 configuration, add this
+to each block of tinc_vpn:
+
+    mode: router
+
+If mode is not set, it defaults to "switch". See the tinc documentation
+for more details on the difference between switch and router mode.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,5 +17,7 @@ tinc_reload: "reload tinc - {{ tinc_init_system }}"
 #    address: <local ip where tinc should listen>
 #    port: 655
 #    compression: 0
-#    subnet: <tun ip address, for vpn access>
+#    vpn_addres: <ip address>
+#    vpn_prefixlength: <prefixlen>
+#    subnet: <network address/prefixlen> # optional
 #    public_key: |

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,7 +23,7 @@
   service:
     name: "tinc@{{ item.vpn }}.service"
     state: reloaded
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo
 
@@ -31,6 +31,6 @@
   service:
     name: "tinc@{{ item.vpn }}.service"
     state: restarted
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo

--- a/tasks/init_systemd.yml
+++ b/tasks/init_systemd.yml
@@ -5,6 +5,6 @@
     name: "tinc@{{ item.vpn }}.service"
     state: started
     enabled: yes
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -6,7 +6,7 @@
     group: root
     state: directory
     recurse: true
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo
   notify: "{{ tinc_restart }}"
@@ -30,7 +30,7 @@
     mode: 0600
     owner: root
     group: root
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo
@@ -43,7 +43,7 @@
     mode: 0644
     owner: root
     group: root
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo
@@ -56,7 +56,7 @@
     owner: root
     group: root
     mode: 0644
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo
   notify: "{{ tinc_reload }}"
@@ -68,7 +68,7 @@
     owner: root
     group: root
     mode: 0755
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo
@@ -81,7 +81,7 @@
     owner: root
     group: root
     mode: 0755
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -16,33 +16,56 @@
   assert:
     that:
       - item.vpn is defined and item.vpn|length > 0
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check tinc_vpn list if name is defined
   assert:
     that:
       - item.name is defined and item.name|length > 0
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check tinc_vpn list if name is unique
   assert:
     that:
       - tinc_vpn|map(attribute='name')|list|length == tinc_vpn|map(attribute='name')|list|unique|length
 
-- name: tinc | check tinc_vpn list if subnet is defined and well formed
+- name: tinc | check tinc_vpn list if address is defined and well formed
   assert:
     that:
-      - item.subnet is defined and item.subnet|length > 0
-      - item.subnet | ipaddr
-      - item.subnet | ipaddr('address')
-      - item.subnet.split('/')[1] | int
-  with_items: tinc_vpn
+      - item.address is defined and item.address|length > 0
+      - item.address | ipaddr
+      - item.address | ipaddr('address')
+  with_items: "{{tinc_vpn}}"
+
+- name: tinc | check tinc_vpn list if subnet is well formed if defined
+  assert:
+    that:
+      - item.subnet is not defined or item.subnet|length > 0
+      - item.subnet is not defined or item.subnet | ipaddr
+      - item.subnet is not defined or item.subnet.split('/')[1] | int
+  with_items: "{{tinc_vpn}}"
+
+- name: tinc | check tinc_vpn list if vpn_address is defined and well formed
+  assert:
+    that:
+      - item.vpn_address is defined and item.vpn_address|length > 0
+      - item.vpn_address | ipaddr
+      - item.vpn_address | ipaddr('address')
+  with_items: "{{tinc_vpn}}"
+
+- name: tinc | check tinc_vpn list if vpn_prefixlength is defined and well formed
+  assert:
+    that:
+      - item.vpn_prefixlength is defined
+      - item.vpn_prefixlength | int
+      - item.vpn_prefixlength >= 0 and item.vpn_prefixlength <= 32
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check tinc_vpn list if public_key is defined
   assert:
     that:
       - item.public_key is defined and item.public_key|length > 0
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check if tinc_hostname in tinc_vpn
   assert:

--- a/templates/host.j2
+++ b/templates/host.j2
@@ -5,6 +5,10 @@ Address={{ item.address }}
 {% endif %}
 Port={{ item.port | default('655') }}
 Compression={{ item.compression | default('0') }}
+{% if 'subnet' in item %}
 Subnet={{ item.subnet }}
+{% else %}
+Subnet={{ item.vpn_address }}/32
+{% endif %}
 
 {{ item.public_key }}

--- a/templates/tinc-up.j2
+++ b/templates/tinc-up.j2
@@ -1,6 +1,8 @@
 #!/bin/sh
-ip address add {{ item.subnet }} dev $INTERFACE
+ip address add {{ item.vpn_address }}/{{ item.vpn_prefixlength }} dev $INTERFACE
 ip link set $INTERFACE up
 {% for host in tinc_vpn %}
+{% if host.subnet is defined %}
 ip route add {{ host.subnet }} dev $INTERFACE
+{% endif %}
 {% endfor %}

--- a/templates/tinc.conf.j2
+++ b/templates/tinc.conf.j2
@@ -1,11 +1,21 @@
 # This file is managed by Ansible, all changes will be lost.
 Name={{ item.name }}
-{% if item.device|d() %}Device={ item.device }{% endif %}
+{% if item.device|d() %}
+Device={{ item.device }}
+{% endif %}
+{% if item.mode|d() %}
+Mode={{ item.mode }}
+{% else %}
 Mode=switch
+{% endif %}
 {% for server in tinc_vpn %}
 {% if item.vpn == server.vpn and item.name != server.name and server.address|d() %}
 ConnectTo={{ server.name }}
 {% endif %}
 {% endfor %}
-{% if tinc_cipher|d() and tinc_cipher %}Cipher={{ tinc_cipher }}{% endif %}
-{% if tinc_digest|d() and tinc_digest %}Digest={{ tinc_digest }}{% endif %}
+{% if tinc_cipher|d() and tinc_cipher %}
+Cipher={{ tinc_cipher }}
+{% endif %}
+{% if tinc_digest|d() and tinc_digest %}
+Digest={{ tinc_digest }}
+{% endif %}


### PR DESCRIPTION
Adds a new vpn_address and vpn_prefix configuration that more
clearly configures a common setup. subnet is now used to specify
a more complicated network setup.

This includes the changes from these PRs, which should be merged prior to this one:
#2
#3
#4

I tested this in both router and switch mode.
