### PR TITLE
Add new features to support more complicated networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+tests/playbook.retry

--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@ An ansible role that installs tinc on Ubuntu.
 
 Tested on ubuntu 14.04 (Trusty), Fedora 24, CentOS7 and RHEL7.
 
-Only tested for L2 mesh setup.
+Tested for L2 mesh ('switch' mode, the default for this role) and routed setup
+('router' mode).
 
 Role Variables
 --------------
 
 Each tinc configuration is mapped to a variable (see `defaults/main.yml`)
 
-Generate an tincd key:
+Generate an tincd key on each host participating in the VPN:
 
     tincd -n test -K4096
 
-With this information set ```tinc_rsa_key```
+With this information set ```tinc_rsa_key``` in host-specific configuration.
 
 In order to setup a simple point to point vpn, common variables:
 
@@ -24,23 +25,32 @@ In order to setup a simple point to point vpn, common variables:
       - vpn: test #vpn name
         name: host1
         address: 192.168.205.10 #local adddress
-        subnet: 172.10.10.10/24 # ip address to use in the vpn interface
+        vpn_interface:
+          - address: 172.10.10.10 # ip address to use in the vpn interface
+            prefixlength: 24 # tells which hosts in VPN are directly reachable
         public_key: |
           -----BEGIN RSA PUBLIC KEY-----
+          [...]
           -----END RSA PUBLIC KEY-----
       - vpn: test
         name: host2
         address: 192.168.205.11
-        subnet: 172.10.10.11/24
+        vpn_interface:
+          - address: 172.10.10.11
+            prefixlength: 24
         public_key: |
           -----BEGIN RSA PUBLIC KEY-----
+          [...]
           -----END RSA PUBLIC KEY-----
+
+Host-specific configuration:
 
 host1:
 
     tinc_hostname: host1
     tinc_rsa_key: |
       -----BEGIN RSA PRIVATE KEY-----
+      [...]
       -----END RSA PRIVATE KEY-----
 
 host2:
@@ -48,7 +58,54 @@ host2:
     tinc_hostname: host2
     tinc_rsa_key: |
       -----BEGIN RSA PRIVATE KEY-----
+      [...]
       -----END RSA PRIVATE KEY-----
+
+This example can be expanded to easily create a fully-connected mesh of more
+than two nodes.
+
+More Complicated Networks
+-------------------------
+If you have a more complicated network, such as where each node in the
+mesh is not fully connected, or where a node has additional hosts behind it,
+you can set the 'subnet' value for each element in tinc_vpn. This will be
+passed directly to the Subnet field in that host's configuration file.
+
+If subnet is not specified in configuration, the Subnet directive will be:
+
+Subnet={{vpn_interface.address}}/32 (or /128 for an IPv6 address)
+
+which tells tinc that each host on the VPN can be contacted directly, which is the
+simplest configuration.
+
+You can also use a combination of external_address and also_connect_to (an array)
+to do more fine-grained control of which nodes can connect to which other nodes,
+and the network interface they use to connect. This is particularly useful
+in a cloud environment where communcation within a datacenter is unmetered
+but communication outside the datacenter is metered.
+
+Multiple VPN Addesses
+---------------------
+vpn_interface is an array that allows you to configure as many addresses as
+you want on the VPN interface. For example, you can have a dual IPv4/IPv6 VPN by
+doing:
+
+vpn_interface:
+  - address: 10.10.10.1
+    prefixlength: 24
+  - address: dead:beef::1
+    prefixlength: 64
+
+Switch vs Router Mode
+---------------------
+
+To use a routed configuration rather than an L2 configuration, set the
+tinc_mode variable to 'router'.
+
+    mode: router
+
+If mode is not set, it defaults to "switch". See the tinc documentation
+for more details on the difference between switch and router mode.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ host1:
 
 host2:
 
-    tinc_hostname: host1
+    tinc_hostname: host2
     tinc_rsa_key: |
       -----BEGIN RSA PRIVATE KEY-----
       -----END RSA PRIVATE KEY-----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 #tinc_hostname: redis3
 tinc_cipher: aes-256-cbc
 tinc_digest: SHA512
+tinc_mode: switch
+tinc_tunnel_server: no
 tinc_init_system: '{{ "systemd"
                    if (ansible_service_mgr|d() and
                        ansible_service_mgr == "systemd")
@@ -17,5 +19,8 @@ tinc_reload: "reload tinc - {{ tinc_init_system }}"
 #    address: <local ip where tinc should listen>
 #    port: 655
 #    compression: 0
-#    subnet: <tun ip address, for vpn access>
+#    vpn_interface:
+#      - address: <ip address>
+#        prefixlength: <prefixlen>
+#    subnet: <network address/prefixlen> # optional
 #    public_key: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 tinc_cipher: aes-256-cbc
 tinc_digest: SHA512
 tinc_mode: switch
-tinc_tunnel_server: no
+tinc_tunnel_server: 'no'
 tinc_init_system: '{{ "systemd"
                    if (ansible_service_mgr|d() and
                        ansible_service_mgr == "systemd")

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,7 +23,7 @@
   service:
     name: "tinc@{{ item.vpn }}.service"
     state: reloaded
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo
 
@@ -31,6 +31,6 @@
   service:
     name: "tinc@{{ item.vpn }}.service"
     state: restarted
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,16 +21,16 @@
 # systemd
 - name: reload tinc - systemd
   service:
-    name: "tinc@{{ item.vpn }}.service"
+    name: "tinc@{{ item }}.service"
     state: reloaded
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn|map(attribute='vpn')|list|unique}}"
   become: yes
   become_method: sudo
 
 - name: restart tinc - systemd
   service:
-    name: "tinc@{{ item.vpn }}.service"
+    name: "tinc@{{ item }}.service"
     state: restarted
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn|map(attribute='vpn')|list|unique}}"
   become: yes
   become_method: sudo

--- a/tasks/init_systemd.yml
+++ b/tasks/init_systemd.yml
@@ -5,6 +5,6 @@
     name: "tinc@{{ item.vpn }}.service"
     state: started
     enabled: yes
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -6,7 +6,7 @@
     group: root
     state: directory
     recurse: true
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo
   notify: "{{ tinc_restart }}"
@@ -30,7 +30,7 @@
     mode: 0600
     owner: root
     group: root
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo
@@ -43,7 +43,7 @@
     mode: 0644
     owner: root
     group: root
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo
@@ -56,7 +56,7 @@
     owner: root
     group: root
     mode: 0644
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   become: yes
   become_method: sudo
   notify: "{{ tinc_reload }}"
@@ -68,7 +68,7 @@
     owner: root
     group: root
     mode: 0755
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo
@@ -81,7 +81,7 @@
     owner: root
     group: root
     mode: 0755
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
   when: tinc_hostname == item.name
   become: yes
   become_method: sudo

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -16,13 +16,13 @@
   assert:
     that:
       - item.vpn is defined and item.vpn|length > 0
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check tinc_vpn list if name is defined
   assert:
     that:
       - item.name is defined and item.name|length > 0
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check tinc_vpn list if name is unique
   assert:
@@ -36,13 +36,13 @@
       - item.subnet | ipaddr
       - item.subnet | ipaddr('address')
       - item.subnet.split('/')[1] | int
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check tinc_vpn list if public_key is defined
   assert:
     that:
       - item.public_key is defined and item.public_key|length > 0
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn}}"
 
 - name: tinc | check if tinc_hostname in tinc_vpn
   assert:

--- a/tasks/test.yml
+++ b/tasks/test.yml
@@ -1,8 +1,10 @@
 ---
 
-- name: tinc | check if tinc_hostname is defined
+- name: tinc | check if tinc_hostname is defined and valid
   assert:
-    that: tinc_hostname is defined and tinc_hostname|length > 0
+    that:
+      - tinc_hostname is defined and tinc_hostname|length > 0
+      - "'-' not in tinc_hostname"
 
 - name: tinc | check if tinc_rsa_key is defined
   assert:
@@ -29,14 +31,39 @@
     that:
       - tinc_vpn|map(attribute='name')|list|length == tinc_vpn|map(attribute='name')|list|unique|length
 
-- name: tinc | check tinc_vpn list if subnet is defined and well formed
+- name: tinc | check tinc_vpn list if address is defined and well formed
   assert:
     that:
-      - item.subnet is defined and item.subnet|length > 0
-      - item.subnet | ipaddr
-      - item.subnet | ipaddr('address')
-      - item.subnet.split('/')[1] | int
+      - item.address is defined and item.address|length > 0
+      - item.address | ipaddr
+      - item.address | ipaddr('address')
   with_items: "{{tinc_vpn}}"
+
+- name: tinc | check tinc_vpn list if subnet is well formed if defined
+  assert:
+    that:
+      - item.subnet is not defined or item.subnet|length > 0
+      - item.subnet is not defined or item.subnet | ipaddr
+      - item.subnet is not defined or item.subnet.split('/')[1] | int
+  with_items: "{{tinc_vpn}}"
+
+- name: tinc | check tinc_vpn.vpn_interface is defined and non-empty
+  assert:
+    that: item.vpn_interface is defined and item.vpn_interface|length > 0
+  with_items: "{{tinc_vpn}}"
+
+- name: tinc | check tinc_vpn list if vpn interface addresses and prefixes are defined and well formed
+  assert:
+    that:
+      - item.1.address is defined and item.1.address|length > 0
+      - item.1.address | ipaddr
+      - item.1.address | ipaddr('address')
+      - item.1.prefixlength is defined
+      - item.1.prefixlength | int
+      - item.1.prefixlength >= 0 and item.1.prefixlength <= 128
+  with_subelements:
+      - "{{tinc_vpn}}"
+      - vpn_interface
 
 - name: tinc | check tinc_vpn list if public_key is defined
   assert:

--- a/templates/host.j2
+++ b/templates/host.j2
@@ -1,10 +1,29 @@
 # This file is managed by Ansible, all changes will be lost.
 Name={{ item.name }}
-{% if 'address' in item %}
+{% if tinc_hostgroup|d() and tinc_hostgroup != item.hostgroup %}
+{% if item.external_address|d() %}
+Address={{ item.external_address }}
+{% endif %}
+{% elif 'address' in item %}
 Address={{ item.address }}
 {% endif %}
 Port={{ item.port | default('655') }}
 Compression={{ item.compression | default('0') }}
+{% if 'subnet' in item %}
+{% if item.subnet is iterable and item.subnet is not string %}
+{% for subnet in item.subnet %}
+Subnet={{subnet}}
+{% endfor %}
+{% else %}
 Subnet={{ item.subnet }}
-
+{% endif %}
+{% else %}
+{% for i in item.vpn_interface %}
+{% if i.address | ipv4() %}
+Subnet={{ i.address }}/32
+{% else %}
+Subnet={{ i.address }}/128
+{% endif %}
+{% endfor %}
+{% endif %}
 {{ item.public_key }}

--- a/templates/tinc-up.j2
+++ b/templates/tinc-up.j2
@@ -1,6 +1,10 @@
 #!/bin/sh
-ip address add {{ item.subnet }} dev $INTERFACE
+{% for i in item.vpn_interface %}
+ip address add {{ i.address }}/{{ i.prefixlength }} dev $INTERFACE
+{% endfor %}
 ip link set $INTERFACE up
 {% for host in tinc_vpn %}
+{% if host.subnet is defined %}
 ip route add {{ host.subnet }} dev $INTERFACE
+{% endif %}
 {% endfor %}

--- a/templates/tinc.conf.j2
+++ b/templates/tinc.conf.j2
@@ -1,11 +1,17 @@
 # This file is managed by Ansible, all changes will be lost.
 Name={{ item.name }}
-{% if item.device|d() %}Device={ item.device }{% endif %}
+{% if item.device|d() %}
+Device={{ item.device }}
+{% endif %}
 Mode=switch
 {% for server in tinc_vpn %}
 {% if item.vpn == server.vpn and item.name != server.name and server.address|d() %}
 ConnectTo={{ server.name }}
 {% endif %}
 {% endfor %}
-{% if tinc_cipher|d() and tinc_cipher %}Cipher={{ tinc_cipher }}{% endif %}
-{% if tinc_digest|d() and tinc_digest %}Digest={{ tinc_digest }}{% endif %}
+{% if tinc_cipher|d() and tinc_cipher %}
+Cipher={{ tinc_cipher }}
+{% endif %}
+{% if tinc_digest|d() and tinc_digest %}
+Digest={{ tinc_digest }}
+{% endif %}

--- a/templates/tinc.conf.j2
+++ b/templates/tinc.conf.j2
@@ -3,12 +3,18 @@ Name={{ item.name }}
 {% if item.device|d() %}
 Device={{ item.device }}
 {% endif %}
-Mode=switch
+Mode={{ tinc_mode }}
 {% for server in tinc_vpn %}
-{% if item.vpn == server.vpn and item.name != server.name and server.address|d() %}
+{% if item.vpn == server.vpn and item.name != server.name and (not item.hostgroup|d() or item.hostgroup == server.hostgroup) and server.address|d() %}
 ConnectTo={{ server.name }}
 {% endif %}
 {% endfor %}
+{% if item.also_connect_to|d() %}
+{% for server in item.also_connect_to %}
+ConnectTo={{ server }}
+{% endfor %}
+{% endif %}
+TunnelServer={{ tinc_tunnel_server }}
 {% if tinc_cipher|d() and tinc_cipher %}
 Cipher={{ tinc_cipher }}
 {% endif %}

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -25,7 +25,10 @@
       - vpn: test_vpn
         name: test
         address: "127.0.0.1"
-        subnet: "10.0.0.1/24"
+        subnet: "10.0.0.0/24"
+        vpn_interface:
+          - address: "10.0.0.1"
+            prefixlength: 24
         public_key: |
           -----BEGIN RSA PUBLIC KEY-----
           MIGJAoGBANAwwkbE2yRBMEtsFc1erw9wcQd0+EzC+AJh3z3tDXNonITTqzKu3kcq


### PR DESCRIPTION
- Support router mode
- Simplify vpn_address config:
  Adds a new vpn_address and vpn_prefix configuration that more
  clearly configures a common setup. subnet is now used to specify
  a more complicated network setup.
- Enable creating a non-fully-connected mesh, with defined hostgroups
  and defined interconnections between them. This is particularly
  suited to cloud environments where communication within a
  datacenter is unmetered but between a datacenter on public addresses
  is metered.

This includes the changes from these PRs, which should be merged prior to this one:
#2
#3
#4

I tested this in both router and switch mode.

This supercedes #5 .
