### PR TITLE
Only restart each VPN once

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,16 +21,16 @@
 # systemd
 - name: reload tinc - systemd
   service:
-    name: "tinc@{{ item.vpn }}.service"
+    name: "tinc@{{ item }}.service"
     state: reloaded
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn|map(attribute='vpn')|list|unique}}"
   become: yes
   become_method: sudo
 
 - name: restart tinc - systemd
   service:
-    name: "tinc@{{ item.vpn }}.service"
+    name: "tinc@{{ item }}.service"
     state: restarted
-  with_items: tinc_vpn
+  with_items: "{{tinc_vpn|map(attribute='vpn')|list|unique}}"
   become: yes
   become_method: sudo


### PR DESCRIPTION
On VPN with many systems, tinc would be restarted N times, one for
each host. Sometimes this would be too fast for systemd and it would
stop the service altogether.